### PR TITLE
Feature/57-parse-strings-correctly

### DIFF
--- a/src/ai_ghostfunctions/ghostfunctions.py
+++ b/src/ai_ghostfunctions/ghostfunctions.py
@@ -109,7 +109,12 @@ def _parse_ai_result(ai_result: Any, expected_return_type: Any) -> Any:
     """
     to_return: str = ai_result["choices"][0]["message"]["content"]
     if expected_return_type is str:
+        if to_return.startswith("'") and to_return.endswith("'"):
+            return ast.literal_eval(to_return)
+        elif to_return.startswith('"') and to_return.endswith('"'):
+            return ast.literal_eval(to_return)
         return to_return
+
     data = ast.literal_eval(to_return)
     return typeguard.check_type(data, expected_return_type)
 

--- a/tests/test_ghostfunctions.py
+++ b/tests/test_ghostfunctions.py
@@ -230,3 +230,23 @@ def test__make_chatgpt_message_from_function_works_well_with_multiline_docstring
         "result = toy_function(x='this')\n"
         "print(result)\n"
     )
+
+
+@pytest.mark.parametrize(
+    "ai_result,expected_return_type,expected_function_result",
+    [
+        ("a bare string", str, "a bare string"),
+        ('"a double quoted string"', str, "a double quoted string"),
+        ("'a single quoted string'", str, "a single quoted string"),
+    ],
+)
+def test___parse_ai_result(
+    ai_result, expected_return_type, expected_function_result
+) -> None:
+    ai_result_wrapper = {"choices": [{"message": {"content": ai_result}}]}
+    assert (
+        ai_ghostfunctions.ghostfunctions._parse_ai_result(
+            ai_result_wrapper, expected_return_type
+        )
+        == expected_function_result
+    )

--- a/tests/test_ghostfunctions.py
+++ b/tests/test_ghostfunctions.py
@@ -241,7 +241,7 @@ def test__make_chatgpt_message_from_function_works_well_with_multiline_docstring
     ],
 )
 def test___parse_ai_result(
-    ai_result, expected_return_type, expected_function_result
+    ai_result: str, expected_return_type: Any, expected_function_result: Any
 ) -> None:
     ai_result_wrapper = {"choices": [{"message": {"content": ai_result}}]}
     assert (


### PR DESCRIPTION
Sometimes, the OpenAI API returns a string something like `'a string'` (with the quotes included in the string). Previously, when we tried to parse it, we would parse it with the quotes inside. This prevents that, by detecting when the return from the AI is enclosed in quotes, and removes them from the ultimate ghostfunction output.